### PR TITLE
Fixes #6, data after subnodes being ignored.

### DIFF
--- a/steam/vdf.py
+++ b/steam/vdf.py
@@ -49,13 +49,14 @@ def _parse(stream, ptr = 0):
     laststr = None
     lasttok = None
     lastbrk = None
-    laststr_is_key = False
+    next_is_value = False
     deserialized = {}
 
     while i < len(stream):
         c = stream[i]
 
         if c == NODE_OPEN:
+            next_is_value = False  # Make sure next string is interpreted as a key.
             deserialized[laststr], i = _parse(stream, i + 1)
         elif c == NODE_CLOSE:
             return deserialized, i
@@ -74,7 +75,7 @@ def _parse(stream, ptr = 0):
             string, i = (
                 _symtostr if c == STRING else
                 _unquotedtostr)(stream, i)
-            if lasttok == STRING and laststr_is_key:
+            if lasttok == STRING and next_is_value:
                 if laststr in deserialized and lastbrk is not None:
                     # ignore this entry if it's the second bracketed expression
                     lastbrk = None
@@ -83,7 +84,7 @@ def _parse(stream, ptr = 0):
             # force c = STRING so that lasttok will be set properly
             c = STRING
             laststr = string
-            laststr_is_key = not laststr_is_key
+            next_is_value = not next_is_value
         else:
             c = lasttok
 

--- a/tests/testvdf.py
+++ b/tests/testvdf.py
@@ -42,6 +42,8 @@ class SyntaxTestCase(unittest.TestCase):
         {
             key value
         }
+
+        "key4" "value"
     }
     """
 
@@ -58,7 +60,8 @@ class SyntaxTestCase(unittest.TestCase):
                 u"key3": u"value",
                 u"subnode": {
                     u"key": u"value"
-                    }
+                    },
+                u"key4": u"value"
                 }
             }
 


### PR DESCRIPTION
My last commit (fixing #4) was causing data listed after a subnode to be misinterpreted, as the keys were being interpreted as values.  This fixes that, and adjusts the tests so that any similar problems will be flagged up in the future.
