### PR TITLE
Added a way to get item quality strings from items loaded via SIM

### DIFF
--- a/steam/sim.py
+++ b/steam/sim.py
@@ -246,7 +246,15 @@ class item(items.item):
             qid = int((self.tool_metadata or {}).get("quality", 0))
         except:
             qid = 0
-        return qid, "normal", "Normal"
+
+        # We might be able to get the quality strings from the item's tags
+        internal_name, name = "normal", "Normal"
+        if 'tags' in self._item:
+            tags = {x.get('category'): x for x in self._item['tags']}
+            if 'Quality' in tags:
+                internal_name, name = tags['Quality'].get('internal_name'), tags['Quality'].get('name')
+
+        return qid, internal_name, name
 
     @property
     def quantity(self):


### PR DESCRIPTION
This allows filtering by quality on optf2 for CSGO items.
