### PR TITLE
Add cells_used method

### DIFF
--- a/steam/items.py
+++ b/steam/items.py
@@ -863,6 +863,11 @@ class inventory(object):
         can be obtained by calling len on an inventory object """
         return self._inv["cells"]
 
+    @property
+    def cells_used(self):
+        """ The total number of used cells in the inventory. """
+        return len(self._inv)
+
     def __getitem__(self, key):
         key = str(key)
         for item in self:


### PR DESCRIPTION
Why do we need this method?

I know that we can call it by len(inventory), but in some cases like using the Flask framework, we have to pass all arguments in the render_template(), so to pass the used slots we would have to create another argument, let's say 'cells_used=len(inventory)', something that can be avoided having a property in the items module to get the length. We have cells_total, why not have this one too?

Without cells_used: `return render_template('profile.html', user=_user, inventory=_inventory, cells_used=len(_inventory))`

With cells_used: `return render_template('profile.html', user=_user, inventory=_inventory)`
