### PR TITLE
added new method for fetching lobbysteamid

### DIFF
--- a/steam/user.py
+++ b/steam/user.py
@@ -179,6 +179,13 @@ class profile(object):
         return (obj.get("locstatecode"), obj.get("loccountrycode"))
 
     @property
+    def lobbysteamid(self):
+        """
+        Returns a lobbynumber as int from few Source games
+        """
+        return int(self._prof["lobbysteamid"])
+
+    @property
     def _prof(self):
         if not self._cache:
             try:


### PR DESCRIPTION
Although this entry in GetPlayerSummaries doesn't figure in official docs, it really does exist for Counter-Strike: Global Offensive (when a player is in matchmaking lobby). It may also be up when player is in lobby in DotA2 or in future TF2 matchmaking.