### PR TITLE
Handle '[]' as the value for g_rgAppContextData so that an InventoryError is properly thrown

### DIFF
--- a/steam/sim.py
+++ b/steam/sim.py
@@ -27,6 +27,9 @@ class inventory_context(object):
                                  data.decode("utf-8"))
             match = contexts.group(1)
             self._cache = json.loads(match)
+            if type(self._cache) != dict:
+                self._cache = {}
+                raise TypeError("Invalid inventory data type")
         except:
             raise items.InventoryError("No SIM inventory information available for this user")
 


### PR DESCRIPTION
This case occurs when a user has a public profile but sets their inventory to private/friends only