### PR TITLE
Use HTTPS API

### DIFF
--- a/steam/api.py
+++ b/steam/api.py
@@ -109,7 +109,7 @@ class _interface_method(object):
                  aggressive=False, data={}, **kwargs):
         kwargs.setdefault("format", "json")
         kwargs.setdefault("key", key.get())
-        url = "http://api.steampowered.com/{0}/{1}/v{2}?{3}".format(self._iface,
+        url = "https://api.steampowered.com/{0}/{1}/v{2}?{3}".format(self._iface,
                                                                     self._name,
                                                                     version,
                                                                     urlencode(kwargs))


### PR DESCRIPTION
I recently noticed unencrypted Steam API calls originating from this library in my home network. This simple patch makes it use the HTTPS endpoint instead.
